### PR TITLE
fix: bug upon update a task, uuid should not change

### DIFF
--- a/src/main/java/cvds/todo/backend/model/TaskModel.java
+++ b/src/main/java/cvds/todo/backend/model/TaskModel.java
@@ -3,6 +3,8 @@ package cvds.todo.backend.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.Objects;
+
 @Document(collection = "tasks")
 public class TaskModel {
     private String id;
@@ -57,5 +59,20 @@ public class TaskModel {
                 ", description='" + description + '\'' +
                 ", done=" + done +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        TaskModel task = (TaskModel) obj;
+        return done == task.done &&
+                Objects.equals(id, task.id) &&
+                Objects.equals(name, task.name) &&
+                Objects.equals(description, task.description);
     }
 }

--- a/src/main/java/cvds/todo/backend/services/TaskService.java
+++ b/src/main/java/cvds/todo/backend/services/TaskService.java
@@ -84,8 +84,7 @@ public class TaskService implements TasksService {
             taskToUpdate.setDescription(task.getDescription() == null ? taskToUpdate.getDescription() : task.getDescription());
             taskToUpdate.setDone(task.isDone());
 
-            this.deleteTask(id);
-            this.createTask(taskToUpdate);
+            this.taskRepository.save(taskToUpdate);
 
             return taskToUpdate;
         }

--- a/src/test/java/cvds/todo/backend/service/TaskServiceTest.java
+++ b/src/test/java/cvds/todo/backend/service/TaskServiceTest.java
@@ -23,17 +23,15 @@ import static org.mockito.Mockito.*;
 @SpringBootTest
 class TaskServiceTest {
 
-    @Mock
-    private TaskRepository taskRepository;
-
-    @InjectMocks
-    private TaskService taskService;
-
     // Define reusable constants for cleaner and more maintainable code
     private static final String EXISTING_TASK_ID = UUID.randomUUID().toString();
     private static final String NON_EXISTING_TASK_ID = "1";
     private static final String TASK_NAME = "Task 1";
     private static final String TASK_DESCRIPTION = "Description 1";
+    @Mock
+    private TaskRepository taskRepository;
+    @InjectMocks
+    private TaskService taskService;
 
     @BeforeEach
     void setUp() {
@@ -106,8 +104,7 @@ class TaskServiceTest {
 
         assertEquals(updatedTask, result, "Updated task should match the provided task model.");
         verify(taskRepository, times(1)).findById(EXISTING_TASK_ID);
-        verify(taskRepository, times(1)).deleteById(EXISTING_TASK_ID);
-        verify(taskRepository, times(1)).insert(any(TaskModel.class));
+        verify(taskRepository, times(1)).save(any(TaskModel.class));
     }
 
     @Test


### PR DESCRIPTION
Override equals methods for TaskModel and bug upon update a task, UUID should not change